### PR TITLE
loki-header: new repeating flag

### DIFF
--- a/deploy/helm/charts/loki-rule-operator/Chart.yaml
+++ b/deploy/helm/charts/loki-rule-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.6.1"
+version: "0.7.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/helm/charts/loki-rule-operator/templates/deployment.yaml
+++ b/deploy/helm/charts/loki-rule-operator/templates/deployment.yaml
@@ -36,6 +36,9 @@ spec:
             - -loki-namespace={{ .Values.lokiRuleOperator.lokiNamespace }}
             - -loki-rule-mount-path={{ .Values.lokiRuleOperator.lokiRuleMountPath }}
             - -loki-url={{ .Values.lokiRuleOperator.lokiURL }}
+            {{- range .Values.lokiRuleOperator.lokiHeaders }}
+            - -loki-header {{ . }}
+            {{- end }}
             {{- if .Values.lokiRuleOperator.logLevel }}
             - -log-level={{ .Values.lokiRuleOperator.logLevel }}
             {{- end }}

--- a/deploy/helm/charts/loki-rule-operator/tests/deployment_test.yaml
+++ b/deploy/helm/charts/loki-rule-operator/tests/deployment_test.yaml
@@ -100,6 +100,45 @@ tests:
       - "-leader-elect=true"
       - "-leader-election-namespace=helm-test"
       - "-leader-election-id=my-id"
+- it: should configure app options with custom headers
+  values:
+    - ./minimal_values.yaml
+  set:
+    lokiRuleOperator:
+      lokiLabelSelector: "app.kubernetes.io/name=loki,app.kubernetes.io/instance=my-loki"
+      lokiNamespace: "loki"
+      lokiRuleMountPath: "/var/loki"
+      lokiURL: "loki.url"
+      lokiHeaders:
+        - X-Foo=Bar
+        - X-Bar=Foo
+      logLevel: debug
+      metrics:
+        port: 9090
+      healthProbe:
+        port: 9091
+      leaderElection:
+        enabled: true
+        id: my-id
+  release:
+    name: "my-release"
+    namespace: "helm-test"
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].args
+        value:
+          - "-loki-label-selector=app.kubernetes.io/name=loki,app.kubernetes.io/instance=my-loki"
+          - "-loki-namespace=loki"
+          - "-loki-rule-mount-path=/var/loki"
+          - "-loki-url=loki.url"
+          - "-loki-header X-Foo=Bar"
+          - "-loki-header X-Bar=Foo"
+          - "-log-level=debug"
+          - "-metrics-bind-address=:9090"
+          - "-health-probe-bind-address=:9091"
+          - "-leader-elect=true"
+          - "-leader-election-namespace=helm-test"
+          - "-leader-election-id=my-id"
 - it: should configure globalOptions
   values:
   - ./minimal_values.yaml

--- a/deploy/helm/charts/loki-rule-operator/values.yaml
+++ b/deploy/helm/charts/loki-rule-operator/values.yaml
@@ -41,4 +41,6 @@ lokiRuleOperator:
     enabled: true
     id: loki-rule-operator.quero.com
   lokiURL: ""
+  # Extra HTTP headers specified as HeaderName=Value which will be passed on to Loki
+  lokiHeaders: []
 keepCrds: false

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -1,0 +1,33 @@
+package flags
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type ArrayFlags []string
+
+func (i *ArrayFlags) String() string {
+	return fmt.Sprintf("%v", &i)
+}
+
+func (i *ArrayFlags) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}
+
+func (i *ArrayFlags) Split(delimiter string) (map[string]string, error) {
+	m := make(map[string]string)
+
+	for _, e := range *i {
+		if !strings.Contains(e, delimiter) {
+			return nil, errors.New(fmt.Sprintf("missing delimiter '%s' in pair: '%s'", delimiter, e))
+		}
+
+		parts := strings.Split(e, delimiter)
+		m[parts[0]] = parts[1]
+	}
+
+	return m, nil
+}

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -1,7 +1,6 @@
 package flags
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 )
@@ -22,7 +21,7 @@ func (i *ArrayFlags) Split(delimiter string) (map[string]string, error) {
 
 	for _, e := range *i {
 		if !strings.Contains(e, delimiter) {
-			return nil, errors.New(fmt.Sprintf("missing delimiter '%s' in pair: '%s'", delimiter, e))
+			return nil, fmt.Errorf("missing delimiter '%s' in pair: '%s'", delimiter, e)
 		}
 
 		parts := strings.Split(e, delimiter)

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -5,20 +5,20 @@ import (
 	"net/http"
 )
 
-type withHeader struct {
+type WithHeader struct {
 	http.Header
 	rt http.RoundTripper
 }
 
-func WithHeader(rt http.RoundTripper) withHeader {
+func ApplyHeader(rt http.RoundTripper) WithHeader {
 	if rt == nil {
 		rt = http.DefaultTransport
 	}
 
-	return withHeader{Header: make(http.Header), rt: rt}
+	return WithHeader{Header: make(http.Header), rt: rt}
 }
 
-func (h withHeader) RoundTrip(req *http.Request) (*http.Response, error) {
+func (h WithHeader) RoundTrip(req *http.Request) (*http.Response, error) {
 	if len(h.Header) == 0 {
 		return h.rt.RoundTrip(req)
 	}
@@ -31,10 +31,10 @@ func (h withHeader) RoundTrip(req *http.Request) (*http.Response, error) {
 	return h.rt.RoundTrip(req)
 }
 
-func HttpClientWithHeaders(extraHeaders *flags.ArrayFlags) *http.Client {
+func ClientWithHeaders(extraHeaders *flags.ArrayFlags) *http.Client {
 	client := &http.Client{}
 
-	rt := WithHeader(client.Transport)
+	rt := ApplyHeader(client.Transport)
 	pairs, err := extraHeaders.Split("=")
 	if err != nil {
 		panic(err)

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -1,0 +1,49 @@
+package http
+
+import (
+	"github.com/quero-edu/loki-rule-operator/internal/flags"
+	"net/http"
+)
+
+type withHeader struct {
+	http.Header
+	rt http.RoundTripper
+}
+
+func WithHeader(rt http.RoundTripper) withHeader {
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
+
+	return withHeader{Header: make(http.Header), rt: rt}
+}
+
+func (h withHeader) RoundTrip(req *http.Request) (*http.Response, error) {
+	if len(h.Header) == 0 {
+		return h.rt.RoundTrip(req)
+	}
+
+	req = req.Clone(req.Context())
+	for k, v := range h.Header {
+		req.Header[k] = v
+	}
+
+	return h.rt.RoundTrip(req)
+}
+
+func HttpClientWithHeaders(extraHeaders *flags.ArrayFlags) *http.Client {
+	client := &http.Client{}
+
+	rt := WithHeader(client.Transport)
+	pairs, err := extraHeaders.Split("=")
+	if err != nil {
+		panic(err)
+	}
+
+	for key, value := range pairs {
+		rt.Set(key, value)
+	}
+	client.Transport = rt
+
+	return client
+}

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ import (
 )
 
 var (
-	scheme           = runtime.NewScheme()
+	scheme = runtime.NewScheme()
 )
 
 func init() {

--- a/main.go
+++ b/main.go
@@ -164,7 +164,7 @@ func main() {
 		Client:                mgr.GetClient(),
 		Scheme:                mgr.GetScheme(),
 		Logger:                log,
-		LokiClient:            httputil.HttpClientWithHeaders(&lokiHeaders),
+		LokiClient:            httputil.ClientWithHeaders(&lokiHeaders),
 		LokiRulesPath:         lokiRuleMountPath,
 		LokiLabelSelector:     lokiSelector,
 		LokiNamespace:         lokiNamespace,

--- a/pkg/controllers/logql_validator.go
+++ b/pkg/controllers/logql_validator.go
@@ -5,12 +5,12 @@ import (
 	"net/url"
 )
 
-func ValidateLogQLOnServerFunc(lokiURL string, logQLExpr string) (bool, error) {
+func ValidateLogQLOnServerFunc(client *http.Client, lokiURL string, logQLExpr string) (bool, error) {
 	logQLExprEscaped := url.QueryEscape(logQLExpr)
 	lokiQueryEndpoint := "/loki/api/v1/query?query=" + logQLExprEscaped
 	logQLURIWithQuery := lokiURL + lokiQueryEndpoint
 
-	response, err := http.Get(logQLURIWithQuery)
+	response, err := client.Get(logQLURIWithQuery)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/controllers/logql_validator_test.go
+++ b/pkg/controllers/logql_validator_test.go
@@ -50,7 +50,7 @@ func TestValidateLogQLOnServerWithHeadersFunc(t *testing.T) {
 
 	defer ts.Close()
 
-	client := httputil.HttpClientWithHeaders(&flags.ArrayFlags{
+	client := httputil.ClientWithHeaders(&flags.ArrayFlags{
 		"X-Scope-Orgid=1",
 		"Authorization=something",
 	})

--- a/pkg/controllers/lokirule_controller_test.go
+++ b/pkg/controllers/lokirule_controller_test.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"path/filepath"
 	"reflect"
 	"time"
@@ -110,7 +111,7 @@ var _ = Describe("LokiRuleController", func() {
 			configMapName := "loki-rule-cfg"
 
 			BeforeEach(func() {
-				handleValidateLogQLResult = func(lokiURL string, queryStringArray []string) bool {
+				handleValidateLogQLResult = func(client *http.Client, lokiURL string, queryStringArray []string) bool {
 					return true
 				}
 				lokiRule = &querocomv1alpha1.LokiRule{


### PR DESCRIPTION
This repeating flag will allow users to pass custom HTTP headers to the Loki instance. E.g. tenant information or custom authorization headers.

Should be invoked by passing extra args to the process like this:
```
  -loki-header X-Scope-Orgid=fake
  -loki-header Authorization=Bearer someToken
 ```