### PR TITLE
add(helm): use commonLabels in chart

### DIFF
--- a/deploy/helm/charts/loki-rule-operator/Chart.yaml
+++ b/deploy/helm/charts/loki-rule-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.8.0"
+version: "0.8.1"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/helm/charts/loki-rule-operator/Chart.yaml
+++ b/deploy/helm/charts/loki-rule-operator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.8.1"
+version: "0.9.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/helm/charts/loki-rule-operator/templates/_helpers.tpl
+++ b/deploy/helm/charts/loki-rule-operator/templates/_helpers.tpl
@@ -41,6 +41,7 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- with .Values.commonLabels }}
+{{ toYaml . }}
 {{- end }}
 {{- end }}
 

--- a/deploy/helm/charts/loki-rule-operator/templates/_helpers.tpl
+++ b/deploy/helm/charts/loki-rule-operator/templates/_helpers.tpl
@@ -40,6 +40,8 @@ helm.sh/chart: {{ include "loki-rule-operator.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/deploy/helm/charts/loki-rule-operator/tests/deployment_test.yaml
+++ b/deploy/helm/charts/loki-rule-operator/tests/deployment_test.yaml
@@ -217,14 +217,3 @@ tests:
   - equal:
       path: spec.template.spec.serviceAccountName
       value: my-service-account
-- it: should set commonLabels
-  values:
-  - ./minimal_values.yaml
-  set:
-    release:
-      name: my-release
-    commonLabels:
-      app.kubernetes.io/name: my-app
-      app.kubernetes.io/instance: my-instance
-  hasDocuments:
-    count: 1

--- a/deploy/helm/charts/loki-rule-operator/tests/deployment_test.yaml
+++ b/deploy/helm/charts/loki-rule-operator/tests/deployment_test.yaml
@@ -217,3 +217,14 @@ tests:
   - equal:
       path: spec.template.spec.serviceAccountName
       value: my-service-account
+- it: should set commonLabels
+  values:
+  - ./minimal_values.yaml
+  set:
+    release:
+      name: my-release
+    commonLabels:
+      app.kubernetes.io/name: my-app
+      app.kubernetes.io/instance: my-instance
+  hasDocuments:
+    count: 1

--- a/deploy/helm/charts/loki-rule-operator/tests/global_test.yaml
+++ b/deploy/helm/charts/loki-rule-operator/tests/global_test.yaml
@@ -1,0 +1,23 @@
+suite: Resources contains commonLabels
+templates:
+- deployment.yaml
+- serviceaccount.yaml
+- crd/quero.com_lokirules.yaml
+- rbac/cluster_role.yaml
+- rbac/leader_election_role.yaml
+- rbac/role_bindings.yaml
+- rbac/lokirule_viewer_role.yaml
+- rbac/lokirule_editor_role.yaml
+tests:
+- it: should set commonLabels in all resources
+  values:
+  - ./minimal_values.yaml
+  set:
+    release:
+      name: my-release
+    commonLabels:
+      global.label/name: my-global-label
+  asserts:
+  - equal:
+      path: metadata.labels["global.label/name"]
+      value: "my-global-label"

--- a/deploy/helm/charts/loki-rule-operator/values.yaml
+++ b/deploy/helm/charts/loki-rule-operator/values.yaml
@@ -13,7 +13,7 @@ serviceAccount:
 
 podAnnotations: {}
 
-# -- Add additional label to all resources
+# -- Add additional labels that will be append in all resources. 
 commonLabels: {}
 
 resources:

--- a/deploy/helm/charts/loki-rule-operator/values.yaml
+++ b/deploy/helm/charts/loki-rule-operator/values.yaml
@@ -13,6 +13,8 @@ serviceAccount:
 
 podAnnotations: {}
 
+commonLabels: {}
+
 resources:
   limits:
     cpu: 200m

--- a/deploy/helm/charts/loki-rule-operator/values.yaml
+++ b/deploy/helm/charts/loki-rule-operator/values.yaml
@@ -13,6 +13,7 @@ serviceAccount:
 
 podAnnotations: {}
 
+# -- Add additional label to all resources
 commonLabels: {}
 
 resources:


### PR DESCRIPTION
 #### PR Description
This PR add `commonsLabels` to be used in all resources

#### Explanation

Labels are key-value pairs that can be a powerful resource for managing, configuring, and troubleshooting. Users can use Kubernetes labels to add meaningful metadata to any Kubernetes object or resource.

#### Notes to the Reviewer
#### PR Checklist
* [x]   Tests 

